### PR TITLE
Review follow-up: release CI gating, storage stream parity, probe/IO hardening, VmapEnsemble privatization

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,8 +5,9 @@ name: Publish
 #
 #   git tag v1.2.3 && git push origin v1.2.3
 #
-# The pushed ``v*`` tag builds the dists, creates a GitHub Release, and publishes
-# to PyPI via Trusted Publishing.
+# The pushed ``v*`` tag runs the test suite, builds the dists, publishes to PyPI
+# via Trusted Publishing, and then creates the GitHub Release. A red tree never
+# publishes, and the GitHub Release is only created after PyPI succeeds.
 
 on:
   push:
@@ -17,8 +18,39 @@ permissions:
   contents: read
 
 jobs:
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: true
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-extras --dev --locked --python ${{ matrix.python-version }}
+
+      - name: Lint
+        run: uv run ruff check probelab tests
+
+      - name: Test
+        run: uv run pytest tests
+
   build:
     name: Build distributions
+    needs: test   # never publish a tag whose tree is red
     runs-on: ubuntu-latest
 
     steps:
@@ -62,7 +94,7 @@ jobs:
 
   github-release:
     name: Create GitHub Release
-    needs: build
+    needs: publish-to-pypi   # only announce a release that actually reached PyPI
     runs-on: ubuntu-latest
     permissions:
       contents: write   # create the GitHub Release for the tag

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased
+
+Added:
+
+- `Activations.to(device=, dtype=)` now casts dtype in addition to moving device.
+- Feature probe `predict`/`predict_logits` accept `batch_size=` and run inference
+  in chunks to bound peak memory.
+- `storage.stream_hdf5` accepts `layers=` (parity with memmap and `load`).
+
+Changed:
+
+- Storage `stream` is unified across backends: HDF5 gains `layers=`, both default
+  `chunk_tokens=500_000`, and `stream_memmap(layers=...)` accepts an int or list.
+- Feature probes now raise `ValueError` on an empty training set instead of
+  returning an uninitialized, unusable probe.
+- `MLP.predict` sets eval mode so dropout never leaks into inference.
+
+Fixed:
+
+- `pool` max pooling over flat activations now chunks like mean pooling, avoiding
+  a large transient on big token sets.
+- `storage.has_memmap` tolerates a corrupt/foreign `meta.json` (returns `False`)
+  so the `format="auto"` dispatcher can fall back to HDF5.
+
+Removed / internal:
+
+- `VmapEnsemble` is now internal (`probelab.utils._vmap_ensemble`); it is no
+  longer exported from `probelab.utils`.
+- Dropped dead code: `types.AggregationMethod`, `Logistic.loss_on_batch`,
+  `MassMean` unused `optimizer_fn`/`scheduler_fn`, an unused `_check_val_loss`
+  parameter, and the unused `[tool.ty]` config.
+
 ## 0.1.0 - 2026-05-27
 
 Initial PyPI release.

--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ make check   # lint + test + build
   title = {probelab: A library for training probes on LLM activations},
   author = {Alex Serrano},
   url = {https://github.com/serteal/probelab},
-  version = {0.1.0},
   year = {2026},
 }
 ```

--- a/probelab/activations.py
+++ b/probelab/activations.py
@@ -748,15 +748,29 @@ class Activations:
     # Device / dtype
     # -------------------------------------------------------------------------
 
-    def to(self, device) -> "Activations":
+    def to(self, device=None, dtype: torch.dtype | None = None) -> "Activations":
+        """Move/cast to *device* and/or *dtype*.
+
+        ``offsets`` and ``detection_mask`` only follow the device move (they stay
+        int64/bool); *dtype* applies to the activation ``data`` only.
+        """
+        data = self.data
+        if device is not None:
+            data = data.to(device)
+        if dtype is not None:
+            data = data.to(dtype)
         return Activations(
-            data=self.data.to(device),
+            data=data,
             dims=self.dims,
-            offsets=self.offsets.to(device) if self.offsets is not None else None,
+            offsets=(
+                self.offsets.to(device)
+                if (self.offsets is not None and device is not None)
+                else self.offsets
+            ),
             detection_mask=(
                 self.detection_mask.to(device)
-                if self.detection_mask is not None
-                else None
+                if (self.detection_mask is not None and device is not None)
+                else self.detection_mask
             ),
             layers=self.layers,
             metadata=self.metadata,

--- a/probelab/collection/__init__.py
+++ b/probelab/collection/__init__.py
@@ -4,9 +4,9 @@
 dialogues and return :class:`~probelab.activations.Activations` (or stream
 backend-neutral :class:`ActivationChunk` objects).
 
-The functions are reachable as ``probelab.collection.collect_activations`` and
-import lazily: the optional ``mirin`` backend is only imported when a function
-is actually called, so ``import probelab`` stays light and dependency-free.
+The functions are reachable as ``probelab.collection.collect_activations``. The
+optional ``mirin`` backend is imported lazily — only when a collection function
+is actually called — so importing probelab never pulls in mirin (or transformers).
 
 Example::
 

--- a/probelab/pool.py
+++ b/probelab/pool.py
@@ -333,24 +333,55 @@ def _flat_max(
 ) -> torch.Tensor:
     """Max pool over flat [T, *] data using offsets and det mask.
 
-    Uses scatter_reduce for vectorized segment reduction.
+    Chunks the input along the sample axis (like :func:`_flat_mean`) so that the
+    per-chunk ``scatter_reduce`` never materializes more than ~`_POOL_CHUNK_TOKENS`
+    tokens worth of masked copies at once. Each chunk holds whole samples, so its
+    segment maxima are final — no cross-chunk stitching needed.
     """
     batch = offsets.shape[0] - 1
-    det_bool = det.to(data.device).bool()
-    total = data.shape[0]
     extra_dims = data.shape[1:]
-    offsets_dev = offsets.to(data.device)
 
-    seg_ids = _segment_ids(offsets_dev, total)
-    # Mask out non-detected tokens with -inf
-    masked_data = data.clone()
-    masked_data[~det_bool] = float("-inf")
+    if batch == 0:
+        return data.new_zeros((0, *extra_dims))
+
+    offsets_cpu = offsets.detach().cpu()
+    det_full = det.to(data.device).bool() if det.device != data.device else det.bool()
 
     out = data.new_full((batch, *extra_dims), float("-inf"))
-    idx = seg_ids.view(-1, *([1] * len(extra_dims))).expand_as(masked_data)
-    out.scatter_reduce_(0, idx, masked_data.to(out.dtype), reduce="amax")
+    # Avoid shadowing the module-level ``max``/``min`` pool functions.
+    import builtins as _b
 
-    # Replace -inf with 0 for segments with no valid tokens
+    s = 0
+    while s < batch:
+        t_start = int(offsets_cpu[s].item())
+        single_sample_len = int((offsets_cpu[s + 1] - offsets_cpu[s]).item())
+        budget = _b.max(_POOL_CHUNK_TOKENS, single_sample_len)
+        target = t_start + budget
+        e = int(torch.searchsorted(
+            offsets_cpu, torch.tensor(target), right=True,
+        ).item()) - 1
+        e = _b.max(e, s + 1)
+        e = _b.min(e, batch)
+        t_end = int(offsets_cpu[e].item())
+
+        chunk_data = data[t_start:t_end]
+        chunk_det = det_full[t_start:t_end]
+        if chunk_data.shape[0] == 0:
+            s = e
+            continue
+
+        chunk_offsets = (offsets[s:e + 1] - offsets[s]).to(data.device)
+        seg_ids = _segment_ids(chunk_offsets, chunk_data.shape[0])
+        # Mask non-detected tokens with -inf only within this chunk.
+        masked = chunk_data.masked_fill(
+            ~chunk_det.view(-1, *([1] * len(extra_dims))), float("-inf")
+        )
+        idx = seg_ids.view(-1, *([1] * len(extra_dims))).expand_as(masked)
+        out[s:e].scatter_reduce_(0, idx, masked.to(out.dtype), reduce="amax")
+
+        s = e
+
+    # Replace -inf with 0 for segments with no valid tokens.
     out[out == float("-inf")] = 0
     return out
 

--- a/probelab/probes/base.py
+++ b/probelab/probes/base.py
@@ -198,6 +198,23 @@ class BaseProbe(nn.Module):
         probs[padded_mask.to(flat_probs.device)] = flat_probs
         return probs
 
+    def _feature_logits_batched(
+        self, features: torch.Tensor, batch_size: int | None = None
+    ) -> torch.Tensor:
+        """Run ``forward`` over *features* in chunks to bound peak memory.
+
+        ``batch_size=None`` falls back to ``self.batch_size`` (or a single pass
+        when the probe has no ``batch_size``). Output matches a one-shot
+        ``self(features)`` call.
+        """
+        n = features.shape[0]
+        if batch_size is None:
+            batch_size = getattr(self, "batch_size", n) or n
+        if n == 0 or batch_size >= n:
+            return self(features)
+        chunks = [self(features[start : start + batch_size]) for start in range(0, n, batch_size)]
+        return torch.cat(chunks, dim=0)
+
     def regularization_loss(self) -> torch.Tensor:
         device, dtype = self._module_device_dtype()
         return torch.zeros((), device=device, dtype=dtype)
@@ -222,9 +239,7 @@ class BaseProbe(nn.Module):
     def _snapshot_best(self) -> None:
         self._best_state = copy.deepcopy(self.state_dict())
 
-    def _check_val_loss(self, val_loss: float, scheduler=None) -> bool:
-        # ``scheduler`` is retained for internal compatibility; training loops
-        # step schedulers on their epoch cadence, not validation cadence.
+    def _check_val_loss(self, val_loss: float) -> bool:
         if val_loss < self._best_val_loss:
             self._best_val_loss = val_loss
             self._patience_counter = 0

--- a/probelab/probes/bilinear.py
+++ b/probelab/probes/bilinear.py
@@ -75,7 +75,10 @@ class Bilinear(BaseProbe):
         if self.device is None:
             self.device = str(X.data.device)
         if features.shape[0] == 0:
-            return self
+            raise ValueError(
+                f"{self.__class__.__name__}.fit received no training features "
+                "(0 samples/tokens after masking). Check the activations and mask."
+            )
         features = features.to(dtype=self._resolve_dtype(features.dtype))
         labels = labels.to(dtype=features.dtype)
         self.initialize(features, labels)
@@ -84,7 +87,8 @@ class Bilinear(BaseProbe):
     def predict_logits(self, X: Activations, **kwargs) -> torch.Tensor:
         self._check_initialized()
         features, _ = self._feature_data_from_activations(X)
-        return self._feature_predict_from_flat(X, self(features))
+        logits = self._feature_logits_batched(features, kwargs.get("batch_size"))
+        return self._feature_predict_from_flat(X, logits)
 
     def predict(self, X: Activations, **kwargs) -> torch.Tensor:
         with torch.no_grad():

--- a/probelab/probes/ee_mlp.py
+++ b/probelab/probes/ee_mlp.py
@@ -106,7 +106,10 @@ class EEMLP(BaseProbe):
         if self.device is None:
             self.device = str(X.data.device)
         if features.shape[0] == 0:
-            return self
+            raise ValueError(
+                f"{self.__class__.__name__}.fit received no training features "
+                "(0 samples/tokens after masking). Check the activations and mask."
+            )
         features = features.to(dtype=self._resolve_dtype(features.dtype))
         labels = labels.to(dtype=features.dtype)
         self.initialize(features, labels)
@@ -115,7 +118,8 @@ class EEMLP(BaseProbe):
     def predict_logits(self, X: Activations, **kwargs) -> torch.Tensor:
         self._check_initialized()
         features, _ = self._feature_data_from_activations(X)
-        return self._feature_predict_from_flat(X, self(features))
+        logits = self._feature_logits_batched(features, kwargs.get("batch_size"))
+        return self._feature_predict_from_flat(X, logits)
 
     def predict(self, X: Activations, **kwargs) -> torch.Tensor:
         with torch.no_grad():

--- a/probelab/probes/logistic.py
+++ b/probelab/probes/logistic.py
@@ -66,19 +66,15 @@ class Logistic(BaseProbe):
         x = (x - self.scaler_mean) / self.scaler_std
         return self.linear(x).squeeze(-1)
 
-    def loss_on_batch(self, features: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        logits = self(features)
-        loss = F.binary_cross_entropy_with_logits(logits, labels)
-        if self.C > 0:
-            loss = loss + (1.0 / (2.0 * self.C)) * self.linear.weight.pow(2).sum() / max(1, labels.numel())
-        return loss
-
     def fit(self, X: Activations, y: list | torch.Tensor, **kwargs) -> "Logistic":
         features, labels = self._feature_data_from_activations(X, y)
         if self.device is None:
             self.device = str(X.data.device)
         if features.shape[0] == 0:
-            return self
+            raise ValueError(
+                f"{self.__class__.__name__}.fit received no training features "
+                "(0 samples/tokens after masking). Check the activations and mask."
+            )
         if features.shape[0] < 2:
             raise ValueError("Logistic requires at least two training samples or tokens.")
         if torch.unique(labels.detach().cpu()).numel() < 2:
@@ -146,7 +142,7 @@ class Logistic(BaseProbe):
     def predict_logits(self, X: Activations, **kwargs) -> torch.Tensor:
         self._check_initialized()
         features, _ = self._feature_data_from_activations(X)
-        logits = self(features)
+        logits = self._feature_logits_batched(features, kwargs.get("batch_size"))
         return self._feature_predict_from_flat(X, logits)
 
     def predict(self, X: Activations, **kwargs) -> torch.Tensor:

--- a/probelab/probes/mass_mean.py
+++ b/probelab/probes/mass_mean.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Callable
 
 import torch
 
@@ -22,8 +21,6 @@ class MassMean(BaseProbe):
         seed: int | None = None,
         device: str | None = None,
         cast: str | None = None,
-        optimizer_fn: Callable | None = None,
-        scheduler_fn: Callable | None = None,
     ):
         super().__init__(device=device, seed=seed, cast=cast)
         self.normalize = normalize
@@ -77,7 +74,10 @@ class MassMean(BaseProbe):
         if self.device is None:
             self.device = str(X.data.device)
         if features.shape[0] == 0:
-            return self
+            raise ValueError(
+                f"{self.__class__.__name__}.fit received no training features "
+                "(0 samples/tokens after masking). Check the activations and mask."
+            )
         if features.shape[0] < 2:
             raise ValueError("MassMean requires at least two training samples or tokens.")
         features = features.to(dtype=self._resolve_dtype(features.dtype))
@@ -87,7 +87,8 @@ class MassMean(BaseProbe):
     def predict_logits(self, X: Activations, **kwargs) -> torch.Tensor:
         self._check_initialized()
         features, _ = self._feature_data_from_activations(X)
-        return self._feature_predict_from_flat(X, self(features))
+        logits = self._feature_logits_batched(features, kwargs.get("batch_size"))
+        return self._feature_predict_from_flat(X, logits)
 
     def predict(self, X: Activations, **kwargs) -> torch.Tensor:
         with torch.no_grad():

--- a/probelab/probes/mlp.py
+++ b/probelab/probes/mlp.py
@@ -72,7 +72,10 @@ class MLP(BaseProbe):
         if self.device is None:
             self.device = str(X.data.device)
         if features.shape[0] == 0:
-            return self
+            raise ValueError(
+                f"{self.__class__.__name__}.fit received no training features "
+                "(0 samples/tokens after masking). Check the activations and mask."
+            )
         features = features.to(dtype=self._resolve_dtype(features.dtype))
         labels = labels.to(dtype=features.dtype)
         self.initialize(features, labels)
@@ -81,10 +84,11 @@ class MLP(BaseProbe):
     def predict_logits(self, X: Activations, **kwargs) -> torch.Tensor:
         self._check_initialized()
         features, _ = self._feature_data_from_activations(X)
-        logits = self(features)
+        logits = self._feature_logits_batched(features, kwargs.get("batch_size"))
         return self._feature_predict_from_flat(X, logits)
 
     def predict(self, X: Activations, **kwargs) -> torch.Tensor:
+        self.eval()
         with torch.no_grad():
             return torch.sigmoid(self.predict_logits(X, **kwargs))
 

--- a/probelab/probes/tpc.py
+++ b/probelab/probes/tpc.py
@@ -128,7 +128,10 @@ class TPC(BaseProbe):
         if self.device is None:
             self.device = str(X.data.device)
         if features.shape[0] == 0:
-            return self
+            raise ValueError(
+                f"{self.__class__.__name__}.fit received no training features "
+                "(0 samples/tokens after masking). Check the activations and mask."
+            )
         features = features.to(dtype=self._resolve_dtype(features.dtype))
         labels = labels.to(dtype=features.dtype)
         self.initialize(features, labels)
@@ -143,7 +146,8 @@ class TPC(BaseProbe):
     def predict_logits(self, X: Activations, **kwargs) -> torch.Tensor:
         self._check_initialized()
         features, _ = self._feature_data_from_activations(X)
-        return self._feature_predict_from_flat(X, self(features))
+        logits = self._feature_logits_batched(features, kwargs.get("batch_size"))
+        return self._feature_predict_from_flat(X, logits)
 
     def predict(self, X: Activations, **kwargs) -> torch.Tensor:
         with torch.no_grad():

--- a/probelab/storage/hdf5.py
+++ b/probelab/storage/hdf5.py
@@ -171,17 +171,31 @@ def load(
 def stream(
     path: str,
     *,
-    chunk_tokens: int = 100_000,
+    layers: int | list[int] | None = None,
+    chunk_tokens: int = 500_000,
     cast: str | None = None,
 ) -> Generator[tuple[Activations, list[int]], None, None]:
-    """Yield activation chunks from an HDF5 file without loading it all."""
+    """Yield activation chunks from a sequence HDF5 file without loading it all.
+
+    Args:
+        path: HDF5 file written by :func:`save` with a sequence (``"s"``) layout.
+        layers: Layer id(s) to keep per chunk (``int`` drops the layer axis,
+            list keeps it, ``None`` keeps all). Only valid for multilayer files.
+        chunk_tokens: Approximate token budget per yielded chunk.
+        cast: Optional dtype name (``"float32"``/``"float16"``/``"bfloat16"``).
+    """
     h5py = _import_h5py()
     target_dtype = _CAST_MAP[cast] if cast else None
 
     with h5py.File(path, "r") as handle:
+        dims = str(handle.attrs["dims"])
+        if "offsets" not in handle or "detection_mask" not in handle:
+            raise ValueError(
+                f"stream() requires a sequence HDF5 file (dims with 's'); got dims={dims!r}. "
+                "Use load() for dense activations."
+            )
         offsets_np = handle["offsets"][:]
         stored_dtype = handle.attrs.get("dtype", "")
-        dims = str(handle.attrs["dims"])
         stored_layers = (
             tuple(int(x) for x in handle["layers"][:])
             if "layers" in handle
@@ -230,12 +244,15 @@ def stream(
                 local_offsets[i - chunk_start + 1] = int(offsets_np[i + 1]) - tok_start
 
             indices = list(range(chunk_start, chunk_end))
-            yield Activations.from_flat(
+            chunk = Activations.from_flat(
                 data=chunk_data,
                 dims=dims,
                 offsets=local_offsets,
                 detection_mask=chunk_mask,
                 layers=stored_layers,
                 metadata=metadata,
-            ), indices
+            )
+            if layers is not None and "l" in dims:
+                chunk = chunk.select("l", layers)
+            yield chunk, indices
             sample_idx = chunk_end

--- a/probelab/storage/memmap.py
+++ b/probelab/storage/memmap.py
@@ -190,7 +190,7 @@ def load(
 def stream(
     dir_path: str,
     *,
-    layers: int | None = None,
+    layers: int | list[int] | None = None,
     chunk_tokens: int = 500_000,
     cast: str | None = None,
 ) -> Generator[tuple[Activations, list[int]], None, None]:
@@ -198,11 +198,13 @@ def stream(
 
     Args:
         dir_path: Directory written by :func:`save`.
-        layers: Single layer id to stream, or ``None`` for all layers.
+        layers: Layer id(s) to stream. An ``int`` yields single-layer ``"bsh"``
+            chunks; a list yields ``"blsh"``; ``None`` streams all layers.
         chunk_tokens: Approximate token budget per yielded chunk.
         cast: Optional dtype name (``"float32"``/``"float16"``/``"bfloat16"``).
     """
     target_dtype = _CAST_MAP[cast] if cast else None
+    single_layer = isinstance(layers, int)
     path = Path(dir_path)
     with open(path / "meta.json") as handle:
         meta = json.load(handle)
@@ -227,7 +229,15 @@ def stream(
         shape=(total_tokens,),
     )
 
-    load_layers = [layers] if layers is not None else all_layers
+    if layers is None:
+        load_layers = list(all_layers)
+    elif single_layer:
+        load_layers = [layers]
+    else:
+        load_layers = list(layers)
+    for layer_id in load_layers:
+        if layer_id not in all_layers:
+            raise ValueError(f"Layer {layer_id} not in stored layers {all_layers}")
     layer_mms = {
         layer_id: np.memmap(
             path / f"layer_{layer_id}.bin",
@@ -256,9 +266,9 @@ def stream(
 
         with warnings.catch_warnings():
             warnings.filterwarnings("ignore", "The given NumPy array is not writable")
-            if layers is not None:
+            if single_layer:
                 chunk_data = torch.from_numpy(
-                    layer_mms[layers][tok_start:tok_end]
+                    layer_mms[load_layers[0]][tok_start:tok_end]
                 ).view(torch.bfloat16)
                 dims = "bsh"
                 stored_layers = None
@@ -267,11 +277,11 @@ def stream(
                     torch.from_numpy(layer_mms[layer_id][tok_start:tok_end]).view(
                         torch.bfloat16
                     )
-                    for layer_id in all_layers
+                    for layer_id in load_layers
                 ]
                 chunk_data = torch.stack(layer_chunks, dim=1)
                 dims = "blsh"
-                stored_layers = tuple(all_layers)
+                stored_layers = tuple(load_layers)
 
         if target_dtype is not None:
             chunk_data = chunk_data.to(target_dtype)
@@ -292,10 +302,18 @@ def stream(
 
 
 def has_memmap(dir_path: str) -> bool:
-    """Return whether a directory contains probelab memmap activations."""
+    """Return whether a directory contains probelab memmap activations.
+
+    Returns ``False`` (rather than raising) for a missing, unreadable, or
+    malformed ``meta.json`` so callers like the storage ``format="auto"``
+    dispatcher can safely probe arbitrary paths.
+    """
     meta_path = Path(dir_path) / "meta.json"
     if not meta_path.exists():
         return False
-    with open(meta_path) as handle:
-        meta = json.load(handle)
-    return meta.get("format") == "memmap_v1"
+    try:
+        with open(meta_path) as handle:
+            meta = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return False
+    return isinstance(meta, dict) and meta.get("format") == "memmap_v1"

--- a/probelab/types.py
+++ b/probelab/types.py
@@ -16,14 +16,6 @@ class Role(str, Enum):
     ASSISTANT = "assistant"
 
 
-class AggregationMethod(str, Enum):
-    MEAN = "mean"
-    MAX = "max"
-    LAST_TOKEN = "last_token"
-    EMA = "ema"
-    ROLLING = "rolling"
-
-
 @dataclass
 class Message:
     """

--- a/probelab/utils/__init__.py
+++ b/probelab/utils/__init__.py
@@ -1,6 +1,9 @@
-"""Utilities for probelab."""
+"""Internal utilities for probelab.
+
+These are implementation helpers, not part of the public API. Import paths and
+signatures here may change without notice.
+"""
 
 from .validation import check_activations
-from .vmap_ensemble import VmapEnsemble, gated_bipolar_regularization
 
-__all__ = ["check_activations", "VmapEnsemble", "gated_bipolar_regularization"]
+__all__ = ["check_activations"]

--- a/probelab/utils/_vmap_ensemble.py
+++ b/probelab/utils/_vmap_ensemble.py
@@ -38,7 +38,9 @@ class VmapEnsemble:
             if ensemble.all_done:
                 break
             for x, mask, y in batches:
-                ensemble.train_step(x, mask, y)
+                # Signature is train_step(x, y, *extra); the mask is an extra
+                # forward arg, so it goes after the labels.
+                ensemble.train_step(x, y, mask)
             val_logits = ensemble.eval_forward_batched(X, val_idx, batch_size)
             ensemble.check_val(val_logits, y_val)
             ensemble.mark_epoch_done(epoch)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -72,9 +72,6 @@ dev = [
 ignore = ["F821"]  # forward annotation errors
 per-file-ignores = { "tests/test_mirin_integration.py" = ["E402"], "tests/test_seed_e2e.py" = ["E402"], "tests/test_tokenization.py" = ["E402"] }
 
-[tool.ty.rules]
-invalid-syntax-in-forward-annotation = "ignore"
-
 [tool.pytest.ini_options]
 addopts = ["-m", "not e2e"]
 testpaths = ["tests"]

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -271,6 +271,31 @@ class TestStorageDispatcher(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "format must be"):
                 storage.save(acts, str(Path(tmp) / "x.h5"), format="zarr")
 
+    def test_has_memmap_tolerates_corrupt_meta(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            d = Path(tmp) / "broken"
+            d.mkdir()
+            (d / "meta.json").write_text("{ this is not json")
+            # Must not raise; a foreign/corrupt dir is simply "not a memmap".
+            self.assertFalse(storage.has_memmap(str(d)))
+
+    def test_memmap_stream_layers_parity(self):
+        acts = Activations(
+            torch.randn(3, 2, 4, 5),
+            detection_mask=torch.ones(3, 4, dtype=torch.bool),
+            dims="blsh",
+            layers=(4, 8),
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "acts.mm"
+            storage.save_memmap(acts, str(path))
+            # int -> single-layer bsh chunks
+            single = list(storage.stream_memmap(str(path), layers=8, chunk_tokens=4))
+            self.assertTrue(all(c.dims == "bsh" for c, _ in single))
+            # list -> multilayer blsh chunks
+            multi = list(storage.stream_memmap(str(path), layers=[8], chunk_tokens=4))
+            self.assertTrue(all(c.dims == "blsh" and c.layers == (8,) for c, _ in multi))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/utils/test_vmap_ensemble.py
+++ b/tests/utils/test_vmap_ensemble.py
@@ -3,7 +3,7 @@
 import torch
 import torch.nn as nn
 
-from probelab.utils.vmap_ensemble import VmapEnsemble, gated_bipolar_regularization
+from probelab.utils._vmap_ensemble import VmapEnsemble, gated_bipolar_regularization
 
 
 class TinyLinear(nn.Module):


### PR DESCRIPTION
Follow-up to #8 — applies the fixes surfaced by the post-merge file-by-file review. Backward-compatible except for the deliberate behavior changes noted below. Verified offline: `ruff check` clean, **455 passed / 43 skipped / 0 failures / 0 errors** (`uv run pytest tests`).

## Correctness & release safety

- **`publish.yml` gates on tests** — runs lint + pytest (3.10/3.11/3.12) before `build`, so a tag whose tree is red never publishes to PyPI. The GitHub Release is now created **after** PyPI publish succeeds (`github-release: needs: publish-to-pypi`), avoiding partial releases.
- **`MLP.predict` sets `eval()`** so dropout can't leak into inference.
- **`pool._flat_max` chunks over samples** like `_flat_mean` (no full-tensor clone / large transient on big token sets).
- **Feature probes raise `ValueError` on empty training input** instead of returning an uninitialized, unsaveable probe.
- **`storage.has_memmap` tolerates a corrupt/foreign `meta.json`** (returns `False`) so the `format="auto"` dispatcher falls back to HDF5 instead of raising.

## API unification & usability

- **`storage` `stream` unified across backends** — HDF5 `stream` gains `layers=`; both default `chunk_tokens=500_000`; `stream_memmap(layers=)` accepts an `int` (single-layer `bsh`) or list (`blsh`). HDF5 `stream` now errors clearly on a dense (non-sequence) file.
- **`Activations.to(device=, dtype=)`** now also casts dtype.
- **Feature-probe `predict`/`predict_logits` accept `batch_size=`** and run inference in chunks (verified equivalent to one-shot) to bound peak memory on large eval sets.

## Cleanup

- **`VmapEnsemble` is now internal** (`probelab.utils._vmap_ensemble`); dropped from `probelab.utils` exports. Fixed its docstring's `train_step` arg order (`train_step(x, y, mask)`).
- Removed dead code: `types.AggregationMethod`, `Logistic.loss_on_batch`, `MassMean`'s unused `optimizer_fn`/`scheduler_fn`, the unused `_check_val_loss` parameter, the unused `[tool.ty]` config, and the hardcoded `version` in the README BibTeX.
- `CHANGELOG.md`: documented the above under **Unreleased**.

## Notes for reviewers

- **Behavior changes:** `MLP` predictions are unaffected numerically but the module is now forced to eval mode in `predict`; feature probes now raise on empty input rather than silently returning a broken probe; `VmapEnsemble` moved import path (it had no other in-repo users).
- I checked the reviewer-suggested `VmapEnsemble.mark_epoch_done` "off-by-one" and it is **not** a bug given the documented loop (`train_step` runs before `mark_epoch_done`), so it was left unchanged.
- `[tool.ty]` was **removed** rather than wired up — proper type-checking of the codebase is its own effort and out of scope here.

## Test plan
- `uv run pytest tests` → 455 passed, 43 skipped, 0 failures/errors
- `uv run ruff check probelab tests examples` → clean

https://claude.ai/code/session_01L1LQ5cs649SkHM7khEn1Ht

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1LQ5cs649SkHM7khEn1Ht)_